### PR TITLE
Fix subgraph health query

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -3,7 +3,7 @@ import { FACTORY_ADDRESS, BUNDLE_ID } from '../constants'
 
 export const SUBGRAPH_HEALTH = gql`
   query health {
-    indexingStatusForCurrentVersion(subgraphName: "ianlapham/uniswapv2") {
+    indexingStatusForCurrentVersion(subgraphName: "1hive/uniswap-v2") {
       synced
       health
       chains {


### PR DESCRIPTION
The health query was querying the wrong subgraph and as a result the `latestBlock` used everywhere else in the app was using the highest block of **mainnet**, not xDai, resulting in graphs not working after xDai's latest block had a higher number than mainnet.