### PR TITLE
Fix token page icon 

### DIFF
--- a/src/components/TokenLogo/index.js
+++ b/src/components/TokenLogo/index.js
@@ -37,7 +37,7 @@ export default function TokenLogo({ address, header = false, size = '24px', ...r
 
   useEffect(() => {
     setError(false)
-  }, [address])
+  }, [address, listedTokensMap])
 
   if (error || BAD_IMAGES[address]) {
     return (


### PR DESCRIPTION
The main icon at `TokenPage` does not load properly. This is due to the mapping of listed tokens not being yet loaded. 

<img width="402" alt="Screen Shot 2020-09-28 at 1 15 53 AM" src="https://user-images.githubusercontent.com/22663232/94390279-99778a80-0128-11eb-9013-401d217d8d5d.png">
